### PR TITLE
feat: platform モジュール改善・wonder_pilot ステータス強化・ビューア刷新

### DIFF
--- a/.claude/scripts/pre-commit-check.sh
+++ b/.claude/scripts/pre-commit-check.sh
@@ -18,6 +18,11 @@ PATTERNS=(
 # このスクリプト自身はチェック対象から除外
 EXCLUDE_FILES=(".claude/scripts/pre-commit-check.sh")
 
+# ダミー値として許可するパターン（誤検知除外）
+DUMMY_PATTERNS=(
+    'api[_-]?key\s*[:=]\s*["'"'"']dummy["'"'"']'
+)
+
 found=0
 
 while IFS= read -r file; do
@@ -36,6 +41,9 @@ while IFS= read -r file; do
     for pat in "${PATTERNS[@]}"; do
         # コメント行（// # * <!--）は除外
         result=$(git show ":$file" | grep -iP -e "$pat" | grep -vP '^\s*(//|#|\*|<!--)' 2>/dev/null || true)
+        for dummy_pat in "${DUMMY_PATTERNS[@]}"; do
+            result=$(echo "$result" | grep -viP "$dummy_pat" || true)
+        done
         if [ -n "$result" ]; then
             echo "[secrets] $file:"
             echo "$result" | head -3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # ai_robotics
 
+応答は日本語で行うこと。
+
 @.claude/rules/firmware.md
 @.claude/rules/coding_style.md
 @.claude/rules/git.md

--- a/docs/project/startup.md
+++ b/docs/project/startup.md
@@ -1,0 +1,37 @@
+# サービス起動手順
+
+## 事前準備
+
+1. **Stack-chan** の電源を入れ、画面に IP アドレスが表示されるまで待つ
+2. **LM Studio** を起動し、モデル（`gemma4:e4b`）をロードしてローカルサーバーを開始する
+
+## 起動（それぞれ別ターミナルで順番に実行）
+
+```bash
+# ① センサー（カメラ）
+cd local_pc/platform/sensors/camera_m5stack
+uv run src/main.py --url <Stack-chanのIP>
+
+# ② 推論
+cd local_pc/platform/inference/lm_studio
+uv run src/main.py
+
+# ③ アクション（サーボ）
+cd local_pc/platform/actions/stackchan_servo
+uv run src/main.py --url <Stack-chanのIP>
+
+# ④ パイロット（①②③ 起動後に実行）
+cd local_pc/platform/pilots/wonder_pilot
+uv run src/main.py
+```
+
+④ を起動するとパイプライン（カメラ → 推論 → サーボ）が動き始める。
+
+## ポート一覧
+
+| モジュール | ポート |
+|---|---|
+| camera_m5stack | 8101 |
+| lm_studio | 8201 |
+| stackchan_servo | 8301 |
+| wonder_pilot | 8000 |

--- a/firmware/m5stack_core_s3/examples/wonder_eye/src/main.cpp
+++ b/firmware/m5stack_core_s3/examples/wonder_eye/src/main.cpp
@@ -8,7 +8,7 @@
 // サーボ: SCS0009（Feetech シリアルバスサーボ）
 //   UART Serial2: RX=GPIO7, TX=GPIO6, 1Mbps、M5IOE1（I2C 0x6F）経由
 //   X軸（水平）: 0〜360度、中央 160度
-//   Y軸（垂直）: 5〜85度、中央 45度（限界角度でロックする恐れがあるため制限）
+//   Y軸（垂直）: 5〜85度、中央 60度（限界角度でロックする恐れがあるため制限）
 //
 // WiFi 設定: SD カード /config.yaml
 //   wifi:
@@ -31,7 +31,7 @@
 
 static const int SD_CS_PIN = 4;
 static const int X_CENTER  = 160;
-static const int Y_CENTER  = 45;
+static const int Y_CENTER  = 60;
 static const int X_MIN     = 0;
 static const int X_MAX     = 360;
 static const int Y_MIN     = 5;

--- a/local_pc/platform/actions/stackchan_servo/src/main.py
+++ b/local_pc/platform/actions/stackchan_servo/src/main.py
@@ -75,7 +75,8 @@ def main():
     parser.add_argument("--port", type=int, default=8301)
     args = parser.parse_args()
 
-    _servo_url = args.url.rstrip("/")
+    url = args.url if args.url.startswith("http") else f"http://{args.url}"
+    _servo_url = url.rstrip("/")
     logger.info(f"Servo URL: {_servo_url}")
     logger.info(f"Port:      {args.port}")
 

--- a/local_pc/platform/actions/stackchan_servo/src/main.py
+++ b/local_pc/platform/actions/stackchan_servo/src/main.py
@@ -71,11 +71,11 @@ async def action_reset():
 def main():
     global _servo_url
     parser = argparse.ArgumentParser()
-    parser.add_argument("--servo-url", default="http://192.168.0.10")
+    parser.add_argument("--url", default="http://192.168.0.10")
     parser.add_argument("--port", type=int, default=8301)
     args = parser.parse_args()
 
-    _servo_url = args.servo_url.rstrip("/")
+    _servo_url = args.url.rstrip("/")
     logger.info(f"Servo URL: {_servo_url}")
     logger.info(f"Port:      {args.port}")
 

--- a/local_pc/platform/inference/lm_studio/src/main.py
+++ b/local_pc/platform/inference/lm_studio/src/main.py
@@ -89,10 +89,11 @@ def main():
     parser.add_argument("--port", type=int, default=8201)
     args = parser.parse_args()
 
-    _client = OpenAI(base_url=args.url, api_key="dummy")
+    url = args.url if args.url.startswith("http") else f"http://{args.url}"
+    _client = OpenAI(base_url=url, api_key="dummy")
     _model = args.model
 
-    logger.info(f"Base URL: {args.url}")
+    logger.info(f"Base URL: {url}")
     logger.info(f"Model:    {_model}")
     logger.info(f"Port:     {args.port}")
 

--- a/local_pc/platform/inference/lm_studio/src/main.py
+++ b/local_pc/platform/inference/lm_studio/src/main.py
@@ -58,7 +58,7 @@ async def infer(body: InferRequest):
                 "type": "json_schema",
                 "json_schema": {
                     "name": "result",
-                    "schema": body.schema,
+                    "schema": body.json_schema,
                     "strict": True,
                 },
             },
@@ -84,15 +84,15 @@ async def infer(body: InferRequest):
 def main():
     global _client, _model
     parser = argparse.ArgumentParser()
-    parser.add_argument("--base-url", default="http://localhost:1234/v1")
+    parser.add_argument("--url", default="http://localhost:1234/v1")
     parser.add_argument("--model", default="gemma4:e4b")
     parser.add_argument("--port", type=int, default=8201)
     args = parser.parse_args()
 
-    _client = OpenAI(base_url=args.base_url, api_key="lm-studio")
+    _client = OpenAI(base_url=args.url, api_key="dummy")
     _model = args.model
 
-    logger.info(f"Base URL: {args.base_url}")
+    logger.info(f"Base URL: {args.url}")
     logger.info(f"Model:    {_model}")
     logger.info(f"Port:     {args.port}")
 

--- a/local_pc/platform/pilots/wonder_pilot/src/main.py
+++ b/local_pc/platform/pilots/wonder_pilot/src/main.py
@@ -100,7 +100,7 @@ def _pilot_loop():
         # 推論
         req = InferRequest(
             prompt=_build_prompt(),
-            schema=INFER_SCHEMA,
+            json_schema=INFER_SCHEMA,
             data=InferData(
                 type="image",
                 content=base64.b64encode(frame).decode(),

--- a/local_pc/platform/pilots/wonder_pilot/src/main.py
+++ b/local_pc/platform/pilots/wonder_pilot/src/main.py
@@ -5,6 +5,7 @@ Port: 8000
 
 Pipeline: SensorModule(/snapshot) → InferenceModule(/infer) → ActionModule(/action)
 """
+
 import argparse
 import base64
 import logging
@@ -22,6 +23,7 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 MODULE_NAME = "wonder_pilot"
+HISTORY_MAX = 3
 
 # X: 0-360 (160=正面中央), Y: 50-85 (60=正面中央)
 INFER_SCHEMA = {
@@ -37,21 +39,15 @@ INFER_SCHEMA = {
 
 PROMPT = """\
 あなたは好奇心旺盛なロボットであり、人間の世界を探索しています。
-同じ場所が5回続いた場合は、xやyの値を大きく変更して新しいものを見るようにすること。
-
 画像の中で最も目を引くものに注目し、JSONスキーマに従って答えてください。
+また、これまでの注目履歴に同じようなものが続いている場合、xやyの値を変更して新しいものを見るようにすること。
 
 X軸（水平）: 0〜360（160が正面中央、小さいほど右、大きいほど左）
 Y軸（垂直）: 50〜85（60が正面中央、小さいほど上、大きいほど下）\
 """
 
-_sensor_url = ""
-_infer_url = ""
-_action_url = ""
-_interval = 0.0
-
-latest_result: dict | None = None
-history: list[dict] = []  # {"time": str, "x": int, "y": int, "reason": str}
+latest: dict | None = None  # {"time", "x", "y", "reason", "image"}
+history: list[dict] = []   # [{"time", "x", "y", "reason", "image"}, ...]
 
 app = FastAPI()
 
@@ -63,53 +59,56 @@ async def health():
 
 @app.get("/status")
 async def status():
-    return {"latest": latest_result, "history": history}
+    return {"latest": latest, "history": history}
 
 
 def _build_prompt() -> str:
     if not history:
         return PROMPT
     lines = "\n".join(
-        f"- [{e['time']}] x={e['x']} y={e['y']} reason={e['reason']}"
-        for e in history
+        f"- [{e['time']}] x={e['x']} y={e['y']} reason={e['reason']}" for e in history
     )
     return PROMPT + f"\n\nこれまでの注目履歴:\n{lines}"
 
 
-def _pilot_loop():
-    global latest_result
+def _pilot_loop(sensor_url: str, infer_url: str, action_url: str, interval: float):
+    global latest
     last_run = 0.0
 
     while True:
         now = time.time()
-        if now - last_run < _interval:
+        if now - last_run < interval:
             time.sleep(0.1)
             continue
         last_run = now
 
         # スナップショット取得
         try:
-            resp = requests.get(f"{_sensor_url}/snapshot", timeout=(10, 30))
+            resp = requests.get(f"{sensor_url}/snapshot", timeout=(10, 30))
             resp.raise_for_status()
             frame = resp.content
+            logger.info(f"Snapshot: {len(frame)} bytes")
         except Exception as e:
             logger.warning(f"Snapshot failed: {e}")
             time.sleep(2)
             continue
 
         # 推論
+        image_b64 = base64.b64encode(frame).decode()
+        prompt = _build_prompt()
+        logger.info("=" * 60)
         req = InferRequest(
-            prompt=_build_prompt(),
+            prompt=prompt,
             json_schema=INFER_SCHEMA,
             data=InferData(
                 type="image",
-                content=base64.b64encode(frame).decode(),
+                content=image_b64,
                 media_type="image/jpeg",
             ),
         )
         try:
             resp = requests.post(
-                f"{_infer_url}/infer", json=req.model_dump(), timeout=60
+                f"{infer_url}/infer", json=req.model_dump(), timeout=60
             )
             resp.raise_for_status()
             result = resp.json()["result"]
@@ -121,17 +120,21 @@ def _pilot_loop():
         y = max(50, min(85, int(result["y"])))
         reason = result.get("reason", "")
         ts = datetime.now().strftime("%H:%M:%S")
-        logger.info(f"[{ts}] x={x} y={y} reason={reason}")
+        logger.info("[RESULT]")
+        logger.info(f"  time:   {ts}")
+        logger.info(f"  x={x}  y={y}")
+        logger.info(f"  reason: {reason}")
+        logger.info("=" * 60)
 
-        latest_result = {"time": ts, "x": x, "y": y, "reason": reason}
-        history.append(latest_result)
-        if len(history) > 10:
+        latest = {"time": ts, "x": x, "y": y, "reason": reason, "image": image_b64}
+        history.append(latest)
+        if len(history) > HISTORY_MAX:
             history.pop(0)
 
         # サーボ移動
         try:
             requests.post(
-                f"{_action_url}/action",
+                f"{action_url}/action",
                 json=ActionRequest(type="move", params={"x": x, "y": y}).model_dump(),
                 timeout=2,
             )
@@ -140,7 +143,6 @@ def _pilot_loop():
 
 
 def main():
-    global _sensor_url, _infer_url, _action_url, _interval
     parser = argparse.ArgumentParser(description="Wonder Pilot")
     parser.add_argument("--sensor-url", default="http://localhost:8101")
     parser.add_argument("--infer-url", default="http://localhost:8201")
@@ -149,18 +151,17 @@ def main():
     parser.add_argument("--port", type=int, default=8000)
     args = parser.parse_args()
 
-    _sensor_url = args.sensor_url.rstrip("/")
-    _infer_url = args.infer_url.rstrip("/")
-    _action_url = args.action_url.rstrip("/")
-    _interval = args.interval
+    sensor_url = args.sensor_url.rstrip("/")
+    infer_url = args.infer_url.rstrip("/")
+    action_url = args.action_url.rstrip("/")
 
-    logger.info(f"Sensor:   {_sensor_url}")
-    logger.info(f"Infer:    {_infer_url}")
-    logger.info(f"Action:   {_action_url}")
-    logger.info(f"Interval: {_interval}s")
+    logger.info(f"Sensor:   {sensor_url}")
+    logger.info(f"Infer:    {infer_url}")
+    logger.info(f"Action:   {action_url}")
+    logger.info(f"Interval: {args.interval}s")
     logger.info(f"Port:     {args.port}")
 
-    threading.Thread(target=_pilot_loop, daemon=True).start()
+    threading.Thread(target=_pilot_loop, args=(sensor_url, infer_url, action_url, args.interval), daemon=True).start()
     uvicorn.run(app, host="0.0.0.0", port=args.port, timeout_graceful_shutdown=0)
 
 

--- a/local_pc/platform/pilots/wonder_pilot/uv.lock
+++ b/local_pc/platform/pilots/wonder_pilot/uv.lock
@@ -292,27 +292,6 @@ wheels = [
 ]
 
 [[package]]
-name = "stackchan-servo"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "fastapi" },
-    { name = "platform-schemas" },
-    { name = "platform-utils" },
-    { name = "requests" },
-    { name = "uvicorn" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastapi", specifier = ">=0.100" },
-    { name = "platform-schemas", editable = "../../schemas" },
-    { name = "platform-utils", editable = "../../utils" },
-    { name = "requests", specifier = ">=2.30" },
-    { name = "uvicorn", specifier = ">=0.20" },
-]
-
-[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -366,4 +345,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+]
+
+[[package]]
+name = "wonder-pilot"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "platform-schemas" },
+    { name = "platform-utils" },
+    { name = "requests" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.100" },
+    { name = "platform-schemas", editable = "../../schemas" },
+    { name = "platform-utils", editable = "../../utils" },
+    { name = "requests", specifier = ">=2.30" },
+    { name = "uvicorn", specifier = ">=0.20" },
 ]

--- a/local_pc/platform/schemas/src/schemas/__init__.py
+++ b/local_pc/platform/schemas/src/schemas/__init__.py
@@ -1,3 +1,3 @@
-from .schemas import ActionRequest, ActionResponse, HealthResponse
+from .schemas import ActionRequest, ActionResponse, HealthResponse, InferData, InferRequest, InferResponse
 
-__all__ = ["ActionRequest", "ActionResponse", "HealthResponse"]
+__all__ = ["ActionRequest", "ActionResponse", "HealthResponse", "InferData", "InferRequest", "InferResponse"]

--- a/local_pc/platform/schemas/src/schemas/schemas.py
+++ b/local_pc/platform/schemas/src/schemas/schemas.py
@@ -15,7 +15,7 @@ class InferData(BaseModel):
 
 class InferRequest(BaseModel):
     prompt: str
-    schema: dict
+    json_schema: dict
     data: InferData | None = None
 
 

--- a/local_pc/platform/sensors/camera_m5stack/src/main.py
+++ b/local_pc/platform/sensors/camera_m5stack/src/main.py
@@ -94,14 +94,18 @@ async def snapshot():
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--url", default="http://192.168.0.9:8101/stream")
+    parser.add_argument("--url", default="http://192.168.0.9:81/stream")
     parser.add_argument("--port", type=int, default=8101)
     args = parser.parse_args()
 
-    logger.info(f"Stream: {args.url}")
+    url = args.url
+    if not url.startswith("http"):
+        url = f"http://{url}:81/stream"
+
+    logger.info(f"Stream: {url}")
     logger.info(f"Port:   {args.port}")
 
-    threading.Thread(target=_read_stream, args=(args.url,), daemon=True).start()
+    threading.Thread(target=_read_stream, args=(url,), daemon=True).start()
     uvicorn.run(app, host="0.0.0.0", port=args.port, timeout_graceful_shutdown=0)
 
 

--- a/local_pc/platform/sensors/camera_m5stack/src/main.py
+++ b/local_pc/platform/sensors/camera_m5stack/src/main.py
@@ -94,14 +94,14 @@ async def snapshot():
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--stream-url", default="http://192.168.0.9:8101/stream")
+    parser.add_argument("--url", default="http://192.168.0.9:8101/stream")
     parser.add_argument("--port", type=int, default=8101)
     args = parser.parse_args()
 
-    logger.info(f"Stream: {args.stream_url}")
+    logger.info(f"Stream: {args.url}")
     logger.info(f"Port:   {args.port}")
 
-    threading.Thread(target=_read_stream, args=(args.stream_url,), daemon=True).start()
+    threading.Thread(target=_read_stream, args=(args.url,), daemon=True).start()
     uvicorn.run(app, host="0.0.0.0", port=args.port, timeout_graceful_shutdown=0)
 
 

--- a/local_pc/platform/sensors/camera_m5stack/uv.lock
+++ b/local_pc/platform/sensors/camera_m5stack/uv.lock
@@ -34,6 +34,27 @@ wheels = [
 ]
 
 [[package]]
+name = "camera-m5stack"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "platform-schemas" },
+    { name = "platform-utils" },
+    { name = "requests" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.100" },
+    { name = "platform-schemas", editable = "../../schemas" },
+    { name = "platform-utils", editable = "../../utils" },
+    { name = "requests", specifier = ">=2.30" },
+    { name = "uvicorn", specifier = ">=0.20" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -289,27 +310,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[[package]]
-name = "stackchan-servo"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "fastapi" },
-    { name = "platform-schemas" },
-    { name = "platform-utils" },
-    { name = "requests" },
-    { name = "uvicorn" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastapi", specifier = ">=0.100" },
-    { name = "platform-schemas", editable = "../../schemas" },
-    { name = "platform-utils", editable = "../../utils" },
-    { name = "requests", specifier = ">=2.30" },
-    { name = "uvicorn", specifier = ">=0.20" },
 ]
 
 [[package]]

--- a/local_pc/platform/viewers/camera/pyproject.toml
+++ b/local_pc/platform/viewers/camera/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "fastapi>=0.100",
     "uvicorn>=0.20",
     "platform-utils",
+    "httpx>=0.28.1",
 ]
 
 [tool.uv.sources]

--- a/local_pc/platform/viewers/camera/src/main.py
+++ b/local_pc/platform/viewers/camera/src/main.py
@@ -1,52 +1,135 @@
 """
-CameraSensorModule の /stream を表示するブラウザビューア。
+Wonder Pilot のステータス（推論画像・結果・履歴）を表示するブラウザビューア。
 
 Port: 8080
 """
 import argparse
 import logging
+import httpx
 import uvicorn
 from fastapi import FastAPI
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from utils import setup_logging
 
 setup_logging()
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
-_stream_url = ""
+_pilot_url = ""
+
+
+@app.get("/api/status")
+async def api_status():
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{_pilot_url}/status", timeout=5.0)
+            resp.raise_for_status()
+            return resp.json()
+    except Exception as e:
+        return JSONResponse(status_code=502, content={"error": str(e)})
 
 
 @app.get("/", response_class=HTMLResponse)
 async def index():
-    return f"""<!DOCTYPE html>
+    return """<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Camera Viewer</title>
+  <title>Wonder Pilot Viewer</title>
   <style>
-    body {{ margin: 0; background: #000; display: flex; justify-content: center; align-items: center; height: 100vh; }}
-    img {{ max-width: 100%; max-height: 100vh; }}
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: #111; color: #eee; font-family: monospace; display: flex; flex-direction: column; height: 100vh; }
+    #main { display: flex; flex: 1; overflow: hidden; }
+    #left { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+    #image-wrap { flex: 1; display: flex; align-items: center; justify-content: center; background: #000; overflow: hidden; }
+    #image-wrap img { max-width: 100%; max-height: 100%; display: block; }
+    #info { padding: 10px 14px; background: #1a1a1a; border-top: 1px solid #333; }
+    #info .coords { font-size: 18px; font-weight: bold; color: #4cf; }
+    #info .reason { margin-top: 4px; color: #ddd; font-size: 13px; }
+    #history { width: 260px; overflow-y: auto; background: #1a1a1a; padding: 8px; }
+    #history h2 { font-size: 12px; color: #888; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 1px; }
+    .hist-item { background: #222; border-radius: 4px; padding: 8px; margin-bottom: 6px; }
+    .hist-item img { width: 100%; border-radius: 2px; margin-bottom: 4px; }
+    .hist-item .meta { font-size: 11px; color: #aaa; }
+    .hist-item .meta .coords { color: #4cf; font-weight: bold; }
+    .hist-item .reason { font-size: 11px; color: #ccc; margin-top: 2px; word-break: break-all; }
+    #status-bar { padding: 4px 12px; font-size: 11px; color: #555; background: #0a0a0a; }
   </style>
 </head>
 <body>
-  <img src="{_stream_url}" />
+  <div id="main">
+    <div id="left">
+      <div id="image-wrap">
+        <img id="latest-img" src="" alt="No image" />
+      </div>
+      <div id="info">
+        <div class="coords" id="coords">--</div>
+        <div class="reason" id="reason">--</div>
+      </div>
+    </div>
+    <div id="history">
+      <h2>History</h2>
+      <div id="hist-list"></div>
+    </div>
+  </div>
+  <div id="status-bar" id="status-bar">Connecting...</div>
+  <script>
+    async function poll() {
+      try {
+        const res = await fetch('/api/status');
+        const data = await res.json();
+        const bar = document.getElementById('status-bar');
+
+        if (data.error) {
+          bar.textContent = 'Error: ' + data.error;
+          return;
+        }
+
+        const latest = data.latest;
+        if (latest) {
+          if (latest.image) {
+            document.getElementById('latest-img').src = 'data:image/jpeg;base64,' + latest.image;
+          }
+          document.getElementById('coords').textContent = `x=${latest.x}  y=${latest.y}`;
+          document.getElementById('reason').textContent = latest.reason || '';
+          bar.textContent = latest.time || '';
+        }
+
+        const hist = (data.history || []).slice().reverse();
+        const list = document.getElementById('hist-list');
+        list.innerHTML = '';
+        for (const e of hist) {
+          const div = document.createElement('div');
+          div.className = 'hist-item';
+          div.innerHTML = (e.image ? `<img src="data:image/jpeg;base64,${e.image}" />` : '') +
+            `<div class="meta"><span class="coords">x=${e.x} y=${e.y}</span>  ${e.time}</div>` +
+            `<div class="reason">${e.reason || ''}</div>`;
+          list.appendChild(div);
+        }
+      } catch (e) {
+        document.getElementById('status-bar').textContent = 'Fetch error: ' + e;
+      }
+    }
+
+    poll();
+    setInterval(poll, 1000);
+  </script>
 </body>
 </html>"""
 
 
 def main():
-    global _stream_url
+    global _pilot_url
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--stream-url", default="http://localhost:8101/stream")
+    parser.add_argument("--url", default="http://localhost:8000")
     parser.add_argument("--port", type=int, default=8080)
     args = parser.parse_args()
 
-    _stream_url = args.stream_url
-    logger.info(f"Stream: {_stream_url}")
-    logger.info(f"Port:   {args.port}")
-    logger.info(f"Open:   http://localhost:{args.port}")
+    _pilot_url = args.url.rstrip("/")
+    logger.info(f"Pilot: {_pilot_url}")
+    logger.info(f"Port:  {args.port}")
+    logger.info(f"Open:  http://localhost:{args.port}")
 
     uvicorn.run(app, host="0.0.0.0", port=args.port)
 

--- a/local_pc/platform/viewers/camera/uv.lock
+++ b/local_pc/platform/viewers/camera/uv.lock
@@ -1,0 +1,287 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e", size = 254831, upload-time = "2026-06-24T20:56:06.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.138.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c9/5e8defe249899c0dc900643695fc07829a67fc88b4ff2cdb03fcbdbf5a4b/fastapi-0.138.1.tar.gz", hash = "sha256:96e3702dce09ee0dce48856135620d3d865ca684a79fe7513fd7b13a12f82862", size = 419646, upload-time = "2026-06-25T15:40:42.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl", hash = "sha256:b994cae7ba8b82c976a728b544244de31333fa5f7d261f9a1dffe526444cae23", size = 129182, upload-time = "2026-06-25T15:40:40.771Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "platform-utils"
+version = "0.1.0"
+source = { editable = "../../utils" }
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+]
+
+[[package]]
+name = "viewer-camera"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "platform-utils" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.100" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "platform-utils", editable = "../../utils" },
+    { name = "uvicorn", specifier = ">=0.20" },
+]


### PR DESCRIPTION
## 変更内容

### schemas
- `InferData` / `InferRequest` / `InferResponse` を `__init__.py` に追加
- `InferRequest.schema` → `json_schema` にリネーム（Pydantic 警告解消）

### 各モジュール共通
- URL 引数を `--url` に統一
- `--url` に scheme がない場合 `http://` を自動補完

### camera_m5stack
- デフォルト URL を wonder_eye のストリームポート（`:81`）に修正

### lm_studio
- ダミー API キー値を `"dummy"` に統一

### stackchan_servo / pre-commit
- `api_key="dummy"` を pre-commit の誤検知除外リストに追加

### wonder_eye (firmware)
- `Y_CENTER` を 45 → 60 に修正（wonder_pilot と統一）

### wonder_pilot
- global 変数を引数渡しにリファクタ
- `HISTORY_MAX` 定数化（3件）
- `/status` に推論画像（base64）を含む `latest` フィールドを追加
- history も画像付きで保持

### viewers/camera
- wonder_pilot の `/status` をポーリングして画像・推論結果・履歴を表示するビューアに刷新
- 座標・reason を画像直下に表示
- 右サイドバーに履歴を画像付きで表示（新しい順）